### PR TITLE
Refactor carousel font settings

### DIFF
--- a/sections/carousel.liquid
+++ b/sections/carousel.liquid
@@ -133,7 +133,7 @@ Visual & interaction refinements for WHOOP-style carousel modal:
 
 /* Responsive font sizes */
 .modal-modal-title {
-  font-size: clamp(1.5rem, 4vw, 2.3rem);
+  font-size: var(--modal-title-size, clamp(1.5rem, 4vw, 2.3rem));
   font-weight: 700;
   line-height: 1.17;
   margin-bottom: 1rem;
@@ -142,7 +142,7 @@ Visual & interaction refinements for WHOOP-style carousel modal:
   text-align: left;
 }
 .modal-modal-desc {
-  font-size: clamp(1rem, 3.2vw, 1.15rem);
+  font-size: var(--modal-desc-size, clamp(1rem, 3.2vw, 1.15rem));
   font-weight: 400;
   line-height: 1.4;
   margin-bottom: 1.8rem;
@@ -150,7 +150,7 @@ Visual & interaction refinements for WHOOP-style carousel modal:
   text-align: left;
 }
 .modal-spotlight-text {
-  font-size: clamp(0.95rem, 2.8vw, 1rem);
+  font-size: var(--modal-spotlight-text-size, clamp(0.95rem, 2.8vw, 1rem));
   font-style: italic;
   color: #666;
   margin-bottom: 0.7rem;
@@ -405,13 +405,7 @@ Visual & interaction refinements for WHOOP-style carousel modal:
             </div>
             <!-- Modal Content (Right) -->
             <div class="modal-right-content w-full md:w-1/2 flex flex-col justify-center overflow-y-auto max-h-[80vh]"
-              style="
-                --modal-title-size: {{ section.settings.modal_title_size | default: 36 }}px;
-                --modal-desc-size: {{ section.settings.modal_desc_size | default: 18 }}px;
-                --modal-spotlight-title-size: {{ section.settings.modal_spotlight_title_size | default: 17 }}px;
-                --modal-spotlight-text-size: {{ section.settings.modal_spotlight_text_size | default: 16 }}px;
-                --modal-spotlight-author-size: {{ section.settings.modal_spotlight_author_size | default: 14 }}px;
-              "
+              :style="styleVars(features[modalIdx])"
             >
               <div class="space-y-3">
                 <div class="text-sm font-medium text-gray-600 uppercase tracking-wider"
@@ -456,6 +450,13 @@ function carouselWithFeatureModal() {
     dragging: false,
     dragStartX: 0,
     dragStartY: 0,
+    defaultSizes: {
+      modal_title_size: {{ section.settings.modal_title_size | default: 36 }},
+      modal_desc_size: {{ section.settings.modal_desc_size | default: 18 }},
+      modal_spotlight_title_size: {{ section.settings.modal_spotlight_title_size | default: 17 }},
+      modal_spotlight_text_size: {{ section.settings.modal_spotlight_text_size | default: 16 }},
+      modal_spotlight_author_size: {{ section.settings.modal_spotlight_author_size | default: 14 }}
+    },
     features: [
       {% for block in section.blocks %}
       {
@@ -469,6 +470,11 @@ function carouselWithFeatureModal() {
         feature_quote: {{ block.settings.feature_quote | json }},
         quote_eyebrow: {{ block.settings.quote_eyebrow | json }},
         quote_author: {{ block.settings.quote_author | json }},
+        modal_title_size: {{ block.settings.modal_title_size | default: section.settings.modal_title_size | default: 36 }},
+        modal_desc_size: {{ block.settings.modal_desc_size | default: section.settings.modal_desc_size | default: 18 }},
+        modal_spotlight_title_size: {{ block.settings.modal_spotlight_title_size | default: section.settings.modal_spotlight_title_size | default: 17 }},
+        modal_spotlight_text_size: {{ block.settings.modal_spotlight_text_size | default: section.settings.modal_spotlight_text_size | default: 16 }},
+        modal_spotlight_author_size: {{ block.settings.modal_spotlight_author_size | default: section.settings.modal_spotlight_author_size | default: 14 }},
       }{% unless forloop.last %},{% endunless %}
       {% endfor %}
       {% if section.blocks.size == 0 %}
@@ -482,7 +488,12 @@ function carouselWithFeatureModal() {
         feature_description: "Understand how your body adapts to training, sleep deprivation, illness, or your menstrual cycle—higher recovery means you're ready for more, while lower recovery signals it's time to rest.",
         feature_quote: "One life lesson that WHOOP has helped instill is that rest and recovery days are needed. Waking up and seeing a low recovery score makes me stop and think of what I can do to help my body.",
         quote_eyebrow: "Member Spotlight",
-        quote_author: "Samantha S."
+        quote_author: "Samantha S.",
+        modal_title_size: {{ section.settings.modal_title_size | default: 36 }},
+        modal_desc_size: {{ section.settings.modal_desc_size | default: 18 }},
+        modal_spotlight_title_size: {{ section.settings.modal_spotlight_title_size | default: 17 }},
+        modal_spotlight_text_size: {{ section.settings.modal_spotlight_text_size | default: 16 }},
+        modal_spotlight_author_size: {{ section.settings.modal_spotlight_author_size | default: 14 }}
       }
       {% endif %}
     ],
@@ -594,6 +605,15 @@ function carouselWithFeatureModal() {
         document.body.classList.add('overflow-hidden');
       }
     },
+    styleVars(feature) {
+      const d = this.defaultSizes;
+      const f = feature || {};
+      return `--modal-title-size: ${(f.modal_title_size || d.modal_title_size)}px;`
+        + ` --modal-desc-size: ${(f.modal_desc_size || d.modal_desc_size)}px;`
+        + ` --modal-spotlight-title-size: ${(f.modal_spotlight_title_size || d.modal_spotlight_title_size)}px;`
+        + ` --modal-spotlight-text-size: ${(f.modal_spotlight_text_size || d.modal_spotlight_text_size)}px;`
+        + ` --modal-spotlight-author-size: ${(f.modal_spotlight_author_size || d.modal_spotlight_author_size)}px;`;
+    },
     closeModal() {
       this.modalOpen = false;
       this.modalIdx = null;
@@ -638,51 +658,6 @@ function carouselWithFeatureModal() {
       "unit": "px",
       "label": "Padding Bottom",
       "default": 52
-    },
-    {
-      "type": "range",
-      "id": "modal_title_size",
-      "label": "Modal Title Font Size (px)",
-      "min": 18,
-      "max": 48,
-      "step": 1,
-      "default": 36
-    },
-    {
-      "type": "range",
-      "id": "modal_desc_size",
-      "label": "Modal Description Font Size (px)",
-      "min": 12,
-      "max": 32,
-      "step": 1,
-      "default": 18
-    },
-    {
-      "type": "range",
-      "id": "modal_spotlight_title_size",
-      "label": "Spotlight Title Font Size (px)",
-      "min": 12,
-      "max": 28,
-      "step": 1,
-      "default": 17
-    },
-    {
-      "type": "range",
-      "id": "modal_spotlight_text_size",
-      "label": "Spotlight Text Font Size (px)",
-      "min": 12,
-      "max": 28,
-      "step": 1,
-      "default": 16
-    },
-    {
-      "type": "range",
-      "id": "modal_spotlight_author_size",
-      "label": "Spotlight Author Font Size (px)",
-      "min": 10,
-      "max": 24,
-      "step": 1,
-      "default": 14
     },
     {
       "type": "text",
@@ -898,6 +873,51 @@ function carouselWithFeatureModal() {
           "id": "quote_author",
           "label": "Quote Author",
           "default": "Samantha S."
+        },
+        {
+          "type": "range",
+          "id": "modal_title_size",
+          "label": "Modal Title Font Size (px)",
+          "min": 18,
+          "max": 48,
+          "step": 1,
+          "default": 36
+        },
+        {
+          "type": "range",
+          "id": "modal_desc_size",
+          "label": "Modal Description Font Size (px)",
+          "min": 12,
+          "max": 32,
+          "step": 1,
+          "default": 18
+        },
+        {
+          "type": "range",
+          "id": "modal_spotlight_title_size",
+          "label": "Spotlight Title Font Size (px)",
+          "min": 12,
+          "max": 28,
+          "step": 1,
+          "default": 17
+        },
+        {
+          "type": "range",
+          "id": "modal_spotlight_text_size",
+          "label": "Spotlight Text Font Size (px)",
+          "min": 12,
+          "max": 28,
+          "step": 1,
+          "default": 16
+        },
+        {
+          "type": "range",
+          "id": "modal_spotlight_author_size",
+          "label": "Spotlight Author Font Size (px)",
+          "min": 10,
+          "max": 24,
+          "step": 1,
+          "default": 14
         }
       ]
     }


### PR DESCRIPTION
## Summary
- move modal font size controls into slide blocks
- compute font-size CSS vars per slide
- use CSS variables in modal typography

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6853fddb806883269942f68485d74244