### PR TITLE
Fix diagonal carousel image binding

### DIFF
--- a/sections/diagonal-media-carousel.liquid
+++ b/sections/diagonal-media-carousel.liquid
@@ -123,7 +123,7 @@ Diagonal Animated Media Carousel
           {% for block in section.blocks %}
             {
               id: {{ block.id | json }},
-              image: {% if block.settings.image != blank %}"{{ block.settings.image | image_url: width: 800 }}"{% else %}null{% endif %},
+              image: {% if block.settings.image != blank %}{{ block.settings.image | image_url: width: 800 | json }}{% else %}null{% endif %},
               title: {{ block.settings.title | json }},
               link: {{ block.settings.link | json }}
             }{% unless forloop.last %},{% endunless %}
@@ -202,6 +202,8 @@ Diagonal Animated Media Carousel
       }
     }
   </script>
+  <!-- Alpine.js for interactive functionality -->
+  <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
 </section>
 
 {% schema %}


### PR DESCRIPTION
## Summary
- ensure image URLs are JSON escaped
- explicitly load Alpine.js inside the carousel section

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6856f3eb9bfc8326abe899035b11c372